### PR TITLE
Show preview bubble for locked availability buttons

### DIFF
--- a/content.css
+++ b/content.css
@@ -206,6 +206,36 @@
   animation:kayak-copy-ping .45s ease-out forwards;
 }
 
+.kayak-copy-preview-bubble{
+  position:fixed;
+  z-index:2147483004;
+  max-width:min(420px, 86vw);
+  padding:10px 14px;
+  border-radius:12px;
+  background:rgba(17,24,39,.94);
+  color:#f9fafb;
+  box-shadow:0 10px 28px rgba(15,23,42,.32);
+  border:1px solid rgba(148,163,184,.28);
+  font:500 12px/1.5 ui-monospace, "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  letter-spacing:.015em;
+  pointer-events:none;
+  user-select:none;
+  opacity:0;
+  transform:translateY(6px);
+  transition:opacity .16s ease, transform .16s ease;
+  white-space:normal;
+  word-break:break-word;
+}
+
+.kayak-copy-preview-bubble--below{
+  transform:translateY(-6px);
+}
+
+.kayak-copy-preview-bubble--visible{
+  opacity:1;
+  transform:translateY(0);
+}
+
 .kayak-copy-btn.kayak-copy-btn--availability.is-copied::after{
   border-radius:999px;
 }


### PR DESCRIPTION
## Summary
- always render Kayak availability buttons even for locked/free users so the commands are visible
- add tooltip-style preview bubble that shows the availability command when hovering locked buttons and keep them disabled for copying
- style the preview bubble to appear above or below the button and hide it automatically on scroll/blur

## Testing
- node converter.test.js *(fails: AssertionError: time wrap should advance to next calendar day for continuing leg)*

------
https://chatgpt.com/codex/tasks/task_e_68db01855d6c8326a9e6e60916bfec47